### PR TITLE
Add details about Elections

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -1,104 +1,97 @@
 # FOSS United Governing Board Charter [Early Draft]
 
-Please see the [Electing a FOSS United Governing board forum topic](https://forum.fossunited.org/t/electing-a-fossunited-governing-board/3569)
-for additional context.
-
-The elected representatives of the FOSS United Governing Board (hereafter refered to as Board),
+The elected representatives of the FOSS United Governing Board (hereafter referred to as GB),
 shall be the primary body responsible for guiding and overseeing the activities of the FOSS United
-Community. The Board is elected to provide support to and strengthen the Community. It shall aim
-to ensure alignment with the goals set out by FOSS United.
+Community. The GB is elected to provide support to and strengthen the Community. It shall define
+and aim to ensure alignment with the goals for the FOSS United Community.
 
-This charter aims to outline all the responsibilities and guidelines for how the Board shall
+This charter aims to outline all the responsibilities and guidelines for how the GB shall
 operate.
 
 ## Mission, Vision, and Values
 
-Governance Structure
-The Board shall consist of three members, all of whom shall be elected through an open and fair
+### Governance Structure
+
+The Board shall consist of five  members, all of whom shall be elected through an open and fair
 election process.
 
-Board meetings shall be required to follow quorum in order to enable a fair voting process for all
+GB meetings shall be required to follow quorum to enable a fair voting process for all
 matters brought forward for the consideration of the Board.
 
-Members of the Board may not be allowed to name or nominate representatives to attend as an
+Members of the GB may not be allowed to name or nominate representatives to attend as an
 alternate.
 
-The Board may invite guests to participate in consideration of specific topics (but such guests
+The GB may invite guests to participate in consideration of specific topics (but such guests
 may not participate in any voting matters).
 
-The Board meetings will be open and public, unless decided otherwise by the Board, in conjunction
-with FOSS United employees(?).
-
-Primary activities of the Board shall be, but not limited to:
-* vote on all decisions or matters coming before the Board; and
-* approve procedures for the nomination and election of any representative of the City Chapters
-  to the Board and any Officer or other positions created by the Board; and
-* oversee all FOSS United business and community outreach matters and work with the appropriate
+Primary activities of the GB shall be, but not limited to:
+* vote on all decisions or matters coming before the GB; and
+* approve procedures for the nomination and election of any representative of the Community
+  to the GB and any Officer or other positions created by the GB; and
+* oversee all FOSS United Foundation and Community activities, and potentially work with the appropriate
   legal help on any legal matters that arise; and
 * adopt and maintain policies or rules and procedures for the various operational policies of
   FOSS United
 
 ## Quorum rules
 
-Quorum for Board meetings will require at least 50 percent of the voting representatives.
+Quorum for GB meetings will require at least 50 percent of the voting representatives.
 
-The Board may continue to meet even if quorum is not met, upon sufficient notice being given in
+The GB may continue to meet even if quorum is not met, upon sufficient notice being given in
 advance, but will be prevented from making any decisions at the meeting.
 
-Consensus, for purposes of Board voting, shall be defined as the lack of sustained objection. If,
-however, any decision requires a vote to move forward, the representatives of the Governing Board
-or Committee, as applicable, will vote on a one vote per voting representative basis. All
-decisions shall be expected to arise from consensus within the Board.
+Consensus, for purposes of GB voting, shall be defined as the lack of sustained objection. If,
+however, any decision requires a vote to move forward, the GB, as applicable, will vote on a
+one vote per voting representative basis. All decisions shall be expected to arise from consensus
+within the GB.
 
-In the event of a tied vote with respect to an action that cannot be resolved by the Governing
-Board, employee representatives of FOSS United(?) shall be asked to step in and help resolve the
+In the event of a tied vote with respect to an action that cannot be resolved by the GB,
+employee representatives of FOSS United shall be asked to step in and help resolve the
 situation.
 
-## Board Composition:
+## Governing Board Composition:
 
-* The Board will be composed of 3 members.
+* The GB will be composed of 5 members.
 * Each member will be elected to a two-year term.
-* There will be an annual election to determine the composition of the TOC for the following year.
-  For the first year alone, _____ (60%) seats will be up for election in one year and two will be
-  up for election the following year.
-* Employees from the same company or related companies* should not hold more than 1 Board seats.
+* There will be an annual election to determine the composition of the GB for the following year.
+  Two seats will be up for election every year.
+* Employees from the same company or related companies* should not hold more than 1 GB seat.
 
 Additional clauses:
-* During any Board election, if the Board membership would exceed this limit even after the
-  natural cycle of Board seat term expirations, enough Board members must resign for it to be
-  possible for the election to yield a diverse enough Board.
-* If a round of Board election cannot produce a diverse enough Board, the limit will not apply
+* During any GB election, if the GB membership would exceed this limit even after the
+  natural cycle of GB seat term expirations, enough GB members must resign for it to be
+  possible for the election to yield a diverse enough GB.
+* If a round of GB election cannot produce a diverse enough GB, the limit will not apply
   until the next election cycle.
-* When a change in employment of a Board member causes their Board membership to exceed this
-  limit, that Board member will be required to resign their TOC membership.
+* When a change in employment of a GB member causes their GB membership to exceed this
+  limit, that GB member will be required to resign their GB membership.
+* GB members can serve a maximum of two consecutive terms.
 
 ## Amendments
 
-The process for amending or modifying this charter begins with the submission of an Amendment
+The process for amending or modifying the Governing Board charter begins with the submission of an Amendment
 Proposal. Any community member is welcome to propose changes, which must be submitted in writing
-(where, TBD - GitHub Issue? Google docs? Email? Forum submission? etc) to the governance
-committee. Each proposal should clearly outline the specific changes and provide a rationale for
-why these changes are necessary.
+via an [email](mailto:governing-board@fossunited.org) to the GB. Each proposal
+should clearly outline the specific changes and provide a rationale for why these changes are necessary.
 
-Once a proposal is received, the “Amendments Committee”, comprising of FOSS United members
-(chosen specifically, GB) will review it within 30 days. During this period, the committee may
-seek additional input from the community to ensure a thorough evaluation. Following the review,
-the proposed amendments will be published on the project’s official communication channels,
-inviting community feedback. An n-day feedback period will be provided, allowing community members
+Once a proposal is received, the “Amendments Committee”, comprising FOSS United Foundation Staff
+and the GB will make it public and review it within 30 days. During this period, the committee may
+seek additional input from the Community to ensure a thorough evaluation. Following the review,
+the proposed amendments will be published on the Community’s official communication channels,
+inviting feedback. A 30-day feedback period will be provided, allowing community members
 to express their support, concerns, or suggestions.
 
-After the feedback period concludes, the governance committee will convene to discuss the proposal
+After the feedback period concludes, the Amendments Committee will convene to discuss the proposal
 and the community’s input. For any amendment or modification to be approved, it must receive a
-two-thirds majority vote from the governance committee.
+two-thirds majority vote from the GB.
 
 Once approved, the amendments will be documented and incorporated into the charter. The updated
-charter will then be published on the project’s official repository and communicated to all
-members.
+charter will then be published publicly and communicated to all members.
 
 In cases where immediate changes are necessary for the safety, security, or legal compliance of
-the project, the governance committee has the authority to enact temporary amendments. These
-emergency amendments will be subject to the standard review and approval process within 60 days to
-ensure they are properly vetted and ratified.
+the project, the GB has the authority to enact temporary amendments. These emergency amendments will
+be subject to the standard review and approval process within 60 days to ensure they are properly
+vetted and ratified.
 
 [Other sections to be added]
 ## Code of Conduct
@@ -106,6 +99,36 @@ ensure they are properly vetted and ratified.
 ## Dispute Resolution
 
 ## Elections
+
+* Elections will be held every year in the month of March
+* An Elections Working Group (WG) will be constituted by the first week of December every year
+* The Elections WG will comprise one member of the GB, one member of the Foundation,
+  and one independent member from the FOSS United Community. Preferably, the tenure
+  of the GB member of the Elections WG ends with the upcoming election,
+  and they aren't contesting in the upcoming election. The independent member from the
+  Community could be one of the candidates who lost the previous election cycle and isn't
+  contesting in the upcoming election
+* The Elections WG will announce the schedule for the upcoming elections by the first week of
+  January every year
+* Along with the election schedule, the Elections WG will also determine the structure of the
+  nomination form, i.e., the personal/professional information that a nominee needs to provide,
+  and the questions that the nominee will need to fill in
+* The Elections WG will solicit nominations from FOSS United and the broader Indian FOSS Community.
+  The Election WG can reach out to individuals and request that they consider running for election.
+  The Election WG will reach out to the Indian FOSS community and the FOSS United Community by
+  working with the Foundation staff and Community volunteers, e.g., newsletter, social media posts, etc
+* The Election WG will delist incomplete nomination forms and announce the final list of
+  nominees to the Community
+* The Election WG will freeze the voter rolls when the final list of nominees is announced
+* A two-week+ voting period will be adopted, similar to the
+  [Open Street Map Foundation](https://osmfoundation.org/wiki/Annual_General_Meetings/2024/Voting_Information_and_Instructions#Voting_duration)
+  and the [Python Software Foundation](https://pyfound.blogspot.com/2024/07/the-2024-psf-board-election-is-open.html).
+  The voting period will open on a Saturday at 00:00 hours and it will end on a Sunday at 23:59 hours
+* Thanks to online voting, the Election WG will announce the results of the election within one day.
+  Ballots will be shared electronically in a public forum, without any personally identifiable information.
+  Please see [Appendix](#how-are-votes-counted) to understand the method by which votes will be counted
+* The Election WG will solicit feedback about the election cycle for a period of one month after
+  the election. After consolidating the feedback and providing it to the Community, the WG will disband
 
 ## Intellectual Property*
 
@@ -116,3 +139,23 @@ ensure they are properly vetted and ratified.
 * When we start supporting projects
 ^ When we start having a Membership program
 ** When we want to govern projects
+
+## Appendix
+
+### History
+
+Please see the evolution of the Governing Board exercise on the FOSS United Forum post -
+[Electing a FOSS United Governing board forum topic](https://forum.fossunited.org/t/electing-a-fossunited-governing-board/3569).
+
+### How are votes counted
+
+The FOSS United Community is expected to rank the nominees from 1 to 5 in their ballot.
+The [Single Transferrable Vote (STV)](https://opavote.com/methods/single-transferable-vote) method will then
+be used to count the votes to determine the makeup of the Governing Board. Specifically,
+the [Scottish STV](https://opavote.com/methods/single-transferable-vote#scottish-stv) or
+[Meek STV](https://opavote.com/methods/single-transferable-vote#meek-stv) methods will be used to count the votes.
+Please note that the [Open Street Map Foundation uses the Scottish STV method](https://osmfoundation.org/wiki/Annual_General_Meetings/2024/Voting_Information_and_Instructions)
+to count the votes for their elections.
+
+Please find explainers about STV in [this video by CGP Grey](https://youtu.be/l8XOZJkozfI?si=vnPZsK5pW24e3tvX)
+and in this video by [the Washington Post](https://youtu.be/2crVSDqHGYY?si=UnaU2eqxAO3g16Sv).

--- a/governance.md
+++ b/governance.md
@@ -54,7 +54,7 @@ situation.
 * The GB will be composed of 5 members.
 * Each member will be elected to a two-year term.
 * There will be an annual election to determine the composition of the GB for the following year.
-  Two seats will be up for election every year.
+  At least two seats will be up for election every year.
 * Employees from the same company or related companies* should not hold more than 1 GB seat.
 
 Additional clauses:


### PR DESCRIPTION
This PR

- update governing board composition from 3 to 5
- mention that at least 2 GB positions will be up for election every year
- adds information about the elections and how the votes are counted, with prior art references to the OSM Foundation and the PSF
- replaces "Board" with "GB", short for Governing Board
- misc edits suggested by Grammarly